### PR TITLE
Remove 'position' and add 'side' and 'align' configurations

### DIFF
--- a/assets/physics-lab-forum.js
+++ b/assets/physics-lab-forum.js
@@ -17,7 +17,8 @@ window.discourseTutorial = {
           "popover": {
             "title": "消息区介绍",
             "description": "点击右上角个人头像可以弹出消息界面",
-            "position": "left",
+            "side": "left",
+            "align": "end",
             "hopeElement": "#current-user.active",
             "nextClick" : "#current-user"
           }
@@ -25,7 +26,7 @@ window.discourseTutorial = {
         {
           "element": "#ember5 > header > div > div > div.panel > div:nth-child(3) > div > div > div > div > div.menu-tabs-container",
           "popover": {
-            "position": "left",
+            "side": "left",
             "title": "消息区介绍",
             "description": "在这里，您可以浏览所有与您有关的消息，点击右侧交互按钮查看对应类别的内容"
           }
@@ -33,7 +34,7 @@ window.discourseTutorial = {
         {
           "element": "#quick-access-all-notifications > div",
           "popover": {
-            "position": "left",
+            "side": "left",
             "title": "消息区介绍",
             "description": "点击这里跳转到用户中心，查看更多内容"
           }


### PR DESCRIPTION
Hello 

I've noticed that the current configuration file includes an unused and unsupported `position` property. Considering the existing schema supports 'side' and 'align' configurations, I decided to remove the `position` property and introduce these two valid properties instead.

![Screenshot_20240331_125208](https://github.com/NetLogo-Mobile/Forum-Theme-Component/assets/155876693/47cc8e90-d5e0-4e68-aeeb-2629bd9def5b)

The changes include:

1. Removal of the 'position' configuration entry.
2. Addition of 'side' and 'align' configurations to align with the expected schema and improve the flexibility and functionality of our system.

I have tested these changes at https://discourse.theme-creator.io/user_themes/8415/preview and everything seems to be working as expected. Please review this pull request and let me know if you have any feedback or suggestions.

Thanks