### PR TITLE
Fixed navigation close logic and completed YAML file configuration and translation.

### DIFF
--- a/assets/physics-lab-forum.js
+++ b/assets/physics-lab-forum.js
@@ -30,8 +30,8 @@ window.discourseTutorial = {
       {
         "element": "#current-user",
         "popover": {
-          "title": locale("message_title"),
-          "description": "点击右上角个人头像可以弹出消息界面",
+          "title": locale("tutorials.logged_startpage.message_area_intro.title"),
+          "description": locale("tutorials.logged_startpage.message_area_intro.description"),
           "side": "left",
           "align": "end",
           "hopeElement": "#current-user.active",
@@ -42,16 +42,16 @@ window.discourseTutorial = {
         "element": ".user-menu.revamped.menu-panel.drop-down",
         "popover": {
           "side": "left",
-          "title": "消息区介绍",
-          "description": "在这里，您可以浏览所有与您有关的消息，点击右侧交互按钮查看对应类别的内容"
+          "title": locale("tutorials.logged_startpage.browse_messages.title"),
+          "description": locale("tutorials.logged_startpage.browse_messages.description")
         }
       },
       {
         "element": "#quick-access-all-notifications > div",
         "popover": {
           "side": "left",
-          "title": "消息区介绍",
-          "description": "点击这里跳转到用户中心，查看更多内容"
+          "title": locale("tutorials.logged_startpage.goto_user_center.title"),
+          "description": locale("tutorials.logged_startpage.goto_user_center.description")
         }
       }
     ],
@@ -59,8 +59,8 @@ window.discourseTutorial = {
       {
         "element": "#main-outlet > div.container.viewing-self > section > div > section > nav > ul",
         "popover": {
-          "title": "个性化设置",
-          "description": "论坛提供了丰富的可自定义 功能，点击选项卡以查看不同功能。如果有任何问题，欢迎搜索或者联系我们<a href='/about'>友好的管理人员</a>"
+          "title": locale("tutorials.summary.personalization_settings.title"),
+          "description": locale("tutorials.summary.personalization_settings.description")
         }
       }
     ],
@@ -68,8 +68,8 @@ window.discourseTutorial = {
       {
         "element": "#user-content > section.user-additional-controls > section",
         "popover": {
-          "title": "共建社区",
-          "description": "欢迎邀请更多用户来到我们的社区，成功邀请后您可以获得限定徽章"
+          "title": locale("tutorials.invited.community_building.title"),
+          "description": locale("tutorials.invited.community_building.description")
         }
       }
     ],
@@ -77,22 +77,22 @@ window.discourseTutorial = {
       {
         "element": "#main-outlet > div.container.viewing-self > section > div > div > div > nav > ul > li.user-nav__preferences-profile",
         "popover": {
-          "title": "个性设置",
-          "description": "填写个人资料，让大家更好的认识你吧！在这里，您可以设置个人网站、用户卡片背景、个性签名等"
+          "title": locale("tutorials.preferences.profile_settings.title"),
+          "description": locale("tutorials.preferences.profile_settings.description")
         }
       },
       {
         "element": "#main-outlet > div.container.viewing-self > section > div > div > div > nav > ul > li.user-nav__preferences-tracking",
         "popover": {
-          "title": "个性设置",
-          "description": "在这里，您可以关注/取消关注特定类别、标签的帖子或话题"
+          "title": locale("tutorials.preferences.follow_unfollow.title"),
+          "description": locale("tutorials.preferences.follow_unfollow.description")
         }
       },
       {
         "element": "#main-outlet > div.container.viewing-self > section > div > div > div > nav > ul > li.user-nav__preferences-users",
         "popover": {
-          "title": "个性设置",
-          "description": "在这里，您可以屏蔽/解除屏蔽特定的用户"
+          "title": locale("tutorials.preferences.block_unblock_users.title"),
+          "description": locale("tutorials.preferences.block_unblock_users.description")
         }
       }
     ],
@@ -100,49 +100,51 @@ window.discourseTutorial = {
       {
         "element": "#user-content",
         "popover": {
-          "title": "更多徽章",
-          "description": "这里列出了您所获得的全部徽章，访问<a href='/badges'>这里</a>可以查看更多未获得徽章"
+          "title": locale("tutorials.own-badges.more_badges.title"),
+          "description": locale("tutorials.own-badges.more_badges.description")
         }
       }
     ],
+    // Pending tests
     "unlogged_startpage": [
       {
         "element": "#site-logo",
         "popover": {
-          "title": "欢迎各位！",
-          "description": "欢迎来到物理实验室网页版社区！在这里，您可以像在APP社区一样发布作品、交流学习，亦或是分享趣事"
+          "title": locale("tutorials.unlogged_startpage.welcome_message.title"),
+          "description": locale("tutorials.unlogged_startpage.welcome_message.description")
         }
       },
       {
         "element": "#ember3 > div.drop-down-mode.d-header-wrap > header > div > div > div.panel > span > span",
         "popover": {
-          "title": "登录账号加入我们吧",
-          "description": " 在新版（2.6.8以后）中，将可以直接从应用访问社区。如果你已经注册了物理实验室帐号，将自动注册或登录网页版交流区帐号。如果你在物实没有验证邮箱，在交流区需要单独验证一次",
+          "title": locale("tutorials.unlogged_startpage.login_invitation.title"),
+          "description": locale("tutorials.unlogged_startpage.login_invitation.description"),
           "hopeElement": "#sidebar-section-content-community > li:nth-child(1)",
           "nextClick": "#ember3 > div.drop-down-mode.d-header-wrap > header > div > div > span > button"
-        },
+        }
       },
       {
         "element": "#d-sidebar",
         "popover": {
-          "title": "点击'≡'打开侧边栏",
-          "description": "在这里，您可以快速跳转到不同分区、标签的帖子，发起或查看私聊、群聊等。更多功能等待您的探索和发现"
+          "title": locale("tutorials.unlogged_startpage.sidebar_navigation.title"),
+          "description": locale("tutorials.unlogged_startpage.sidebar_navigation.description")
         }
       }
-    ], //Pending tests
+    ],
+
     "badges_list": [
       {
         "element": "#main-outlet > section > div > h1",
         "popover": {
-          "title": "什么是徽章？",
-          "description": "徽章是在论坛上用来表彰用户特定成就、贡献或者参与度的一种图标或徽记。完成特定的任务、达到一定的活跃度、获得特定的荣誉或者对社区做出杰出贡献都有机会获得属于您的徽章。"
+          "title": locale("tutorials.badges_list.badge_explanatio.title"),
+          "description": locale("tutorials.badges_list.badge_explanatio.description")
         }
       },
       {
         "element": ".badge-card",
         "popover": {
-          "title": "如何获得徽章？",
-          "description": "点击具体徽章可以查看获取条件等，注册之后，也可以在我的-徽章里面查看并佩戴已获得的徽章",
+          "title": locale("tutorials.badges_list.how_to_get_badges.title"),
+          "description": locale("tutorials.badges_list.how_to_get_badges.description"),
           "hopeElement": "#sidebar-section-content-community > li:nth-child(1)",
           "nextClick": ".btn-sidebar-toggle"
         }
@@ -150,8 +152,8 @@ window.discourseTutorial = {
       {
         "element": ".sidebar-more-section-links-details-summary",
         "popover": {
-          "title": "徽章列表",
-          "description": " 一些徽章的获得的条件是公开的，在导航栏-更多-徽章页面，您可以看到公开的徽章列表。",
+          "title": locale("tutorials.badges_list.badge_list.title"),
+          "description": locale("tutorials.badges_list.badge_list.description"),
           "side": "top",
           "align": 'start'
         },
@@ -161,22 +163,22 @@ window.discourseTutorial = {
       {
         "element": "#main-outlet > div.container.tags-index > div.list-controls > div > h2",
         "popover": {
-          "title": "关于标签",
-          "description": "除了自带的语言标签外，用户可以给自己的帖子带上相关的标签。点击“≡”打开侧边栏，可以快速查看不同标签分类下的内容"
+          "title": locale("tutorials.tag_list.about_tags.title"),
+          "description": locale("tutorials.tag_list.about_tags.description")
         }
       },
       {
         "element": ".tags-list.tag-list",
         "popover": {
-          "title": "更多标签",
-          "description": "如果您有任何有关标签的建议，都可以发布帖子让我们知道您的意见和建议，欢迎您与我们共建论坛"
+          "title": locale("tutorials.tag_list.more_tags.title"),
+          "description": locale("tutorials.tag_list.more_tags.description")
         }
       },
       {
         "element": ".tag-box",
         "popover": {
-          "title": "快速跳转",
-          "description": "点击不同标签可以跳转至对应标签的帖子列表。tips：您也可以在作品列表或搜索的时候指定特定的标签"
+          "title": locale("tutorials.tag_list.quick_jump.title"),
+          "description": locale("tutorials.tag_list.quick_jump.description")
         }
       }
     ],
@@ -184,31 +186,32 @@ window.discourseTutorial = {
       {
         "element": ".navigation-container",
         "popover": {
-          "title": "关于类别",
-          "description": "每一个帖子都只能选择一个类别，为了避免错误分类，请阅读不同类别下应该发表什么样的帖子"
+          "title": locale("tutorials.categories.about_categories.title"),
+          "description": locale("tutorials.categories.about_categories.description")
         }
       },
       {
         "element": ".category-box.category-box-general",
         "popover": {
-          "title": "共建社区",
-          "description": "发现有帖子分类，可以点击下方 旗帜 形状的图标提示管理人员，详情查看<a href='/t/topic/294/1'>如何反馈不恰当内容</a>"
+          "title": locale("tutorials.categories.build_community.title"),
+          "description": locale("tutorials.categories.build_community.description")
         }
       }
     ],
+    // Pending tests
     "unlogged_firstPost": [
       {
         "element": "#topic-title",
         "popover": {
-          "title": "加入讨论吧",
-          "description": "优秀的看法总是在交流中诞生，注册或登录，与大家一齐讨论吧。"
+          "title": locale("tutorials.unlogged_firstPost.join_discussion.title"),
+          "description": locale("tutorials.unlogged_firstPost.join_discussion.description")
         }
       },
       {
         "element": "#post_1 > div > div.topic-avatar",
         "popover": {
-          "title": "用户资料",
-          "description": "不论是话题的发起者还是回复者，都可以点击头像查看TA的资料/名片。同时，您在发表看法的时候也无需署名",
+          "title": locale("tutorials.unlogged_firstPost.user_profile.title"),
+          "description": locale("tutorials.unlogged_firstPost.user_profile.description"),
           "hopeElement": "#user-card > div > div.card-row.first-row",
           "nextClick": "#post_1 > div > div.topic-avatar > div > a"
         },
@@ -217,82 +220,78 @@ window.discourseTutorial = {
       {
         "element": "#user-card > div",
         "popover": {
-          "title": "用户名片",
-          "description": "点击用户名可以查看详细资料，注册账号后，您也可以填写并生成您独一无二的名片"
+          "title": locale("tutorials.unlogged_firstPost.user_card.title"),
+          "description": locale("tutorials.unlogged_firstPost.user_card.description")
         }
       }
 
-    ], //Pending tests
+    ],
     "logged_firstPost": [
       {
         "element": ".topic-notifications-button",
         "popover": {
-          "title": "通知设置",
-          "description": "您可以在此设置有关本话题活动的消息提示方式，例如：是否需要在有回复的时候显示为未读。对于您回复过的话题，我们会有一些默认的设置，您可以在个人设置-消息通知里面进行修改"
+          "title": locale("tutorials.logged_firstPost.notification_settings.title"),
+          "description": locale("tutorials.logged_firstPost.notification_settings.description")
         }
       },
       {
         "element": ".actions",
         "popover": {
-          "title": "相关操作",
-          "description": "操作栏里面可以进行点赞、翻译、收藏、加入书签、编辑帖子（如有权限）等操作。如果您认为帖子有不合适的地方，可以点击旗帜图标进行举报"
-        },
-
+          "title": locale("tutorials.logged_firstPost.relevant_actions.title"),
+          "description": locale("tutorials.logged_firstPost.relevant_actions.description")
+        }
       },
       {
         "element": "widget-button.reply.create",
         "popover": {
-          "title": "参与讨论",
-          "description": "交流时请保持友善，共建美好社区。您可以点击侧边栏-更多-常见问题解答 查看发言注意事项请，或搜索FAQ"
+          "title": locale("tutorials.logged_firstPost.participate_discussion.title"),
+          "description": locale("tutorials.logged_firstPost.participate_discussion.description")
         }
       }
-
     ],
     "group": [
       {
         "element": ".groups-header",
         "popover": {
-          "title": "什么是群组？",
-          "description": "“群组”功能允许用户创建和加入特定主题或兴趣小组，促进围绕共同话题的深入交流与合作。"
+          "title": locale("tutorials.group.what_is_group.title"),
+          "description": locale("tutorials.group.what_is_group.description")
         }
       },
       {
         "element": ".group-box",
         "popover": {
-          "title": "加入群组",
-          "description": "除了系统默认的群组之外，你也可以加入一个群组与志同道合的人一起讨论。点击群组卡片，查看细内容，您可以选择直接申请或者通过私信功能与群组的管理员联系"
-        },
-
+          "title": locale("tutorials.group.join_group.title"),
+          "description": locale("tutorials.group.join_group.description")
+        }
       },
       {
         "element": "[data-group-name='admins']",
         "popover": {
-          "title": "创建一个群组",
-          "description": "您可以随时私信联系<a href='/about'>管理人员</a>创建一个特定的群组并将您设定为群组管理人员"
+          "title": locale("tutorials.group.create_group.title"),
+          "description": locale("tutorials.group.create_group.description")
         }
       },
       {
         "element": "[data-group-name='Editors-Chinese']",
         "popover": {
-          "title": "联系组织人员",
-          "description": "一些群组可能在APP和社区内为大家提供特定的帮助，您可以点击卡片查看详细说明、联系成员或者查看群组活动"
+          "title": locale("tutorials.group.contact_organizers.title"),
+          "description": locale("tutorials.group.contact_organizers.description")
         }
       }
-
     ],
-    "about":[
+    "about": [
       {
         "element": "section.about.admins > h3",
         "popover": {
-          "title": "关于“管理人员”",
-          "description": "有任何意见、建议、反馈都可以随时联系我们的管理人员，如果您希望创建新的标签、类别、群组，也可以发布帖子或者和管理人员一同讨论"
+          "title": locale("tutorials.about.about_admins.title"),
+          "description": locale("tutorials.about.about_admins.description")
         }
       },
       {
         "element": ".user-info",
         "popover": {
-          "title": "私信功能",
-          "description": "您可以通过“私信”与管理人员取得联系（当然，也可以通过私信联系其他用户）"
+          "title": locale("tutorials.about.private_messaging.title"),
+          "description": locale("tutorials.about.private_messaging.description")
         }
       }
     ],
@@ -300,22 +299,22 @@ window.discourseTutorial = {
       {
         "element": "#user-content",
         "popover": {
-          "title": "什么是“通知”？",
-          "description": "通知是系统向用户发送的信息，例如：当有人回复、点赞、@、私信你，或是有新的话题符合你的关注设定。"
+          "title": locale("tutorials.notifications.what_are_notifications.title"),
+          "description": locale("tutorials.notifications.what_are_notifications.description")
         }
       },
       {
         "element": ".user-nav__personal-messages",
         "popover": {
-          "title": "“通知”与“消息”",
-          "description": "二者并不相同。消息也就是私信功能的收件箱，比如用户可以通过站内信功能向其他用户发送个人消息，进行一对一的沟通"
+          "title": locale("tutorials.notifications.notifications_and_messages.title"),
+          "description": locale("tutorials.notifications.notifications_and_messages.description")
         }
       },
       {
         "element": ".user-nav__preferences",
         "popover": {
-          "title": "个性化设置",
-          "description": "通知可以根据用户的偏好设置为即时推送、邮件通知等形式"
+          "title": locale("tutorials.notifications.personalization.title"),
+          "description": locale("tutorials.notifications.personalization.description")
         }
       }
     ],
@@ -323,15 +322,15 @@ window.discourseTutorial = {
       {
         "element": ".category-breadcrumb",
         "popover": {
-          "title": "什么是“消息”？",
-          "description": "消息是用户间的交流内容，如主题讨论、私信、评论等。点击用户头像，在弹出的用户卡片里面点击私信按钮即可与用户一对一沟通"
+          "title": locale("tutorials.messages.what_are_messages.title"),
+          "description": locale("tutorials.messages.what_are_messages.description")
         }
       },
       {
         "element": ".new-private-message",
         "popover": {
-          "title": "群发消息",
-          "description": "类似邮件，您也可以同时将消息发送给多位用户，此时就类似创建了一个小的群聊，只有选择的用户可以看到有关信息"
+          "title": locale("tutorials.messages.group_messaging.title"),
+          "description": locale("tutorials.messages.group_messaging.description")
         }
       }
     ]

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,4 +2,144 @@ en:
   done: Done
   next: Next
   prev: Previous
-  message_title: "Notification Area"
+  tutorials:
+    logged_startpage:
+      message_area_intro:
+        title: Message Area Introduction
+        description: Click on the profile avatar at the top right to open the message interface
+      browse_messages:
+        title: Browse Messages
+        description: Here, you can browse all messages related to you. Click on the interaction buttons on the right to view content by category.
+      goto_user_center:
+        title: Go to User Center
+        description: Click here to navigate to the user center and view more content
+
+    summary:
+      personalization_settings:
+        title: Personalization Settings
+        description: The forum offers a variety of customizable features. Click on tabs to view different functionalities. If you have any questions, feel free to search or contact our <a href='/about'>friendly administrators</a>
+
+    invited:
+      community_building:
+        title: Community Building
+        description: Welcome to invite more users to our community. Upon successful invitation, you can receive exclusive badges
+
+    preferences:
+      profile_settings:
+        title: Profile Settings
+        description: Fill out your personal information to let everyone know you better! Here, you can set your personal website, user card background, signature, etc.
+      follow_unfollow:
+        title: Follow and Unfollow
+        description: Here, you can follow/unfollow posts or topics of specific categories or tags
+      block_unblock_users:
+        title: Block and Unblock Users
+        description: Here, you can block/unblock specific users
+        
+    own-badges:
+      more_badges:
+        title: More Badges
+        description: Here lists all the badges you've earned. Visit <a href='/badges'>here</a> to see more badges you haven't earned yet.
+
+    unlogged_startpage:
+      welcome_message:
+        title: Welcome Everyone!
+        description: Welcome to the Physics Lab web community! Here, you can publish works, learn, and share interesting things just like in the app community.
+      login_invitation:
+        title: Log in to join us
+        description: Starting from version 2.6.8, you can access the community directly from the app. If you already have a Physics Lab account, you will automatically register or log in to the web forum. If your email has not been verified in Physics Lab, you will need to verify it separately in the forum.
+      sidebar_navigation:
+        title: Sidebar Navigation
+        description: Click '≡' to open the sidebar. Here, you can quickly jump to posts in different sections and tags, start or view private chats, group chats, and more. More features await your exploration and discovery.
+
+    badges_list:
+      badge_explanation:
+        title: What are Badges?
+        description: Badges are icons or marks awarded on the forum to recognize user achievements, contributions, or participation. Completing specific tasks, maintaining certain activity levels, earning particular honors, or making outstanding contributions to the community can earn you badges.
+      how_to_get_badges:
+        title: How to Earn Badges?
+        description: Click on specific badges to see the criteria for earning them. After registration, you can also view and wear badges you've earned under My - Badges.
+      badge_list:
+        title: Badge List
+        description: Some badge criteria are publicly available. You can see a list of publicly available badges in the navigation bar under More - Badges.
+
+    tag_list:
+      about_tags:
+        title: About Tags
+        description: In addition to the default language tags, users can add relevant tags to their posts. Click '≡' to open the sidebar and quickly view content under different tag categories.
+      more_tags:
+        title: More Tags
+        description: If you have suggestions regarding tags, feel free to post and let us know your thoughts and suggestions. We welcome your participation in building the forum.
+      quick_jump:
+        title: Quick Jump
+        description: Clicking on different tags allows you to jump to the corresponding post list. Tips: You can also specify specific tags in the work list or during searches.
+
+    categories:
+      about_categories:
+        title: About Categories
+        description: Each post can only be assigned to one category. To avoid misclassification, please read what types of posts should be posted under different categories.
+      build_community:
+        title: Building Community
+        description: If you find a post misclassified, you can click on the flag icon below to alert the moderators. For more details, see <a href='/t/topic/294/1'>How to Report Inappropriate Content</a>.
+	
+  	unlogged_firstPost:
+    	join_discussion:
+      	title: Join the Discussion
+      	description: Great ideas are born through communication. Register or log in to discuss with everyone.
+    	user_profile:
+      	title: User Profile
+      	description: Whether you initiate topics or respond to them, click on the avatar to view the user's profile/card. You can express your opinions without the need for attribution.
+    	user_card:
+      	title: User Card
+      	description: Click on the username to view detailed information. After registering, you can also fill out and generate your unique profile card.
+  
+  	logged_firstPost:
+    	notification_settings:
+      	title: Notification Settings
+      	description: Here you can set how you receive notifications about topic activities, such as whether to mark replies as unread. Default settings are applied to topics you've replied to, which you can modify in your profile settings under Message Notifications.
+    	relevant_actions:
+      	title: Relevant Actions
+      description: The action bar allows you to like, translate, bookmark, edit posts (if permitted), and more. If you find any inappropriate content, click the flag icon to report it.
+    	participate_discussion:
+      	title: Participate in Discussions
+      	description: Please maintain a friendly tone when engaging in discussions to build a better community. You can check the posting guidelines by clicking Sidebar > More > FAQs or searching FAQs.
+      	
+  	group:
+    	what_is_group:
+      	title: What is a Group?
+      	description: The "Group" feature allows users to create and join specific topic or interest groups, facilitating deeper discussions and collaborations around common interests.
+    	join_group:
+      	title: Join a Group
+      	description: Besides default groups, you can join a group to discuss with like-minded individuals. Click on the group card to view details; you can choose to apply directly or contact group admins via private messaging.
+    	create_group:
+      	title: Create a Group
+      	description: You can contact <a href='/about'>administrators</a> to create a specific group and appoint yourself as a group administrator.
+    	contact_organizers:
+      	title: Contact Organizers
+      	description: Some groups may provide specific help through the app and community. Click on the card to view detailed instructions, contact members, or check group activities.
+  
+  	about:
+    	about_admins:
+      	title: About "Administrators"
+      	description: Feel free to contact our administrators with any opinions, suggestions, or feedback. If you wish to create new tags, categories, or groups, you can also post or discuss with administrators.
+    	private_messaging:
+      	title: Private Messaging
+      	description: You can contact administrators via "Private Messages." Of course, you can also communicate with other users through private messaging.
+  
+  	notifications:
+    	what_are_notifications:
+      	title: What are Notifications?
+      	description: Notifications are messages sent by the system to users, such as when someone replies, likes, mentions (@), or sends a private message to you, or when new topics match your interests.
+    	notifications_and_messages:
+      	title: Notifications vs. Messages
+      	description: Notifications and messages are different. Messages refer to communication between users, such as topic discussions, private messages, comments, etc. Click on a user's avatar and then the "Private Message" button in the user card to communicate one-on-one with them.
+    	personalization:
+      	title: Personalization Settings
+      	description: Notifications can be personalized to be delivered instantly, via email, or other forms based on user preferences.
+
+  	messages:
+    	what_are_messages:
+      	title: What are Messages?
+      	description: Messages are exchanges between users, such as topic discussions, private messages, comments, etc. Click on a user's avatar, then click the "Private Message" button in the user card to communicate one-on-one with them.
+    	group_messaging:
+      	title: Group Messaging
+      	description: Similar to emails, you can also send messages to multiple users simultaneously, creating a small group chat where only selected users can see the information.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -80,66 +80,66 @@ en:
       build_community:
         title: Building Community
         description: If you find a post misclassified, you can click on the flag icon below to alert the moderators. For more details, see <a href='/t/topic/294/1'>How to Report Inappropriate Content</a>.
-	
-  	unlogged_firstPost:
-    	join_discussion:
-      	title: Join the Discussion
-      	description: Great ideas are born through communication. Register or log in to discuss with everyone.
-    	user_profile:
-      	title: User Profile
-      	description: Whether you initiate topics or respond to them, click on the avatar to view the user's profile/card. You can express your opinions without the need for attribution.
-    	user_card:
-      	title: User Card
-      	description: Click on the username to view detailed information. After registering, you can also fill out and generate your unique profile card.
   
-  	logged_firstPost:
-    	notification_settings:
-      	title: Notification Settings
-      	description: Here you can set how you receive notifications about topic activities, such as whether to mark replies as unread. Default settings are applied to topics you've replied to, which you can modify in your profile settings under Message Notifications.
-    	relevant_actions:
-      	title: Relevant Actions
+    unlogged_firstPost:
+      join_discussion:
+        title: Join the Discussion
+        description: Great ideas are born through communication. Register or log in to discuss with everyone.
+      user_profile:
+        title: User Profile
+        description: Whether you initiate topics or respond to them, click on the avatar to view the user's profile/card. You can express your opinions without the need for attribution.
+      user_card:
+        title: User Card
+        description: Click on the username to view detailed information. After registering, you can also fill out and generate your unique profile card.
+  
+    logged_firstPost:
+      notification_settings:
+        title: Notification Settings
+        description: Here you can set how you receive notifications about topic activities, such as whether to mark replies as unread. Default settings are applied to topics you've replied to, which you can modify in your profile settings under Message Notifications.
+      relevant_actions:
+        title: Relevant Actions
       description: The action bar allows you to like, translate, bookmark, edit posts (if permitted), and more. If you find any inappropriate content, click the flag icon to report it.
-    	participate_discussion:
-      	title: Participate in Discussions
-      	description: Please maintain a friendly tone when engaging in discussions to build a better community. You can check the posting guidelines by clicking Sidebar > More > FAQs or searching FAQs.
-      	
-  	group:
-    	what_is_group:
-      	title: What is a Group?
-      	description: The "Group" feature allows users to create and join specific topic or interest groups, facilitating deeper discussions and collaborations around common interests.
-    	join_group:
-      	title: Join a Group
-      	description: Besides default groups, you can join a group to discuss with like-minded individuals. Click on the group card to view details; you can choose to apply directly or contact group admins via private messaging.
-    	create_group:
-      	title: Create a Group
-      	description: You can contact <a href='/about'>administrators</a> to create a specific group and appoint yourself as a group administrator.
-    	contact_organizers:
-      	title: Contact Organizers
-      	description: Some groups may provide specific help through the app and community. Click on the card to view detailed instructions, contact members, or check group activities.
+      participate_discussion:
+        title: Participate in Discussions
+        description: Please maintain a friendly tone when engaging in discussions to build a better community. You can check the posting guidelines by clicking Sidebar > More > FAQs or searching FAQs.
+        
+    group:
+      what_is_group:
+        title: What is a Group?
+        description: The "Group" feature allows users to create and join specific topic or interest groups, facilitating deeper discussions and collaborations around common interests.
+      join_group:
+        title: Join a Group
+        description: Besides default groups, you can join a group to discuss with like-minded individuals. Click on the group card to view details; you can choose to apply directly or contact group admins via private messaging.
+      create_group:
+        title: Create a Group
+        description: You can contact <a href='/about'>administrators</a> to create a specific group and appoint yourself as a group administrator.
+      contact_organizers:
+        title: Contact Organizers
+        description: Some groups may provide specific help through the app and community. Click on the card to view detailed instructions, contact members, or check group activities.
   
-  	about:
-    	about_admins:
-      	title: About "Administrators"
-      	description: Feel free to contact our administrators with any opinions, suggestions, or feedback. If you wish to create new tags, categories, or groups, you can also post or discuss with administrators.
-    	private_messaging:
-      	title: Private Messaging
-      	description: You can contact administrators via "Private Messages." Of course, you can also communicate with other users through private messaging.
+    about:
+      about_admins:
+        title: About "Administrators"
+        description: Feel free to contact our administrators with any opinions, suggestions, or feedback. If you wish to create new tags, categories, or groups, you can also post or discuss with administrators.
+      private_messaging:
+        title: Private Messaging
+        description: You can contact administrators via "Private Messages." Of course, you can also communicate with other users through private messaging.
   
-  	notifications:
-    	what_are_notifications:
-      	title: What are Notifications?
-      	description: Notifications are messages sent by the system to users, such as when someone replies, likes, mentions (@), or sends a private message to you, or when new topics match your interests.
-    	notifications_and_messages:
-      	title: Notifications vs. Messages
-      	description: Notifications and messages are different. Messages refer to communication between users, such as topic discussions, private messages, comments, etc. Click on a user's avatar and then the "Private Message" button in the user card to communicate one-on-one with them.
-    	personalization:
-      	title: Personalization Settings
-      	description: Notifications can be personalized to be delivered instantly, via email, or other forms based on user preferences.
+    notifications:
+      what_are_notifications:
+        title: What are Notifications?
+        description: Notifications are messages sent by the system to users, such as when someone replies, likes, mentions (@), or sends a private message to you, or when new topics match your interests.
+      notifications_and_messages:
+        title: Notifications vs. Messages
+        description: Notifications and messages are different. Messages refer to communication between users, such as topic discussions, private messages, comments, etc. Click on a user's avatar and then the "Private Message" button in the user card to communicate one-on-one with them.
+      personalization:
+        title: Personalization Settings
+        description: Notifications can be personalized to be delivered instantly, via email, or other forms based on user preferences.
 
-  	messages:
-    	what_are_messages:
-      	title: What are Messages?
-      	description: Messages are exchanges between users, such as topic discussions, private messages, comments, etc. Click on a user's avatar, then click the "Private Message" button in the user card to communicate one-on-one with them.
-    	group_messaging:
-      	title: Group Messaging
-      	description: Similar to emails, you can also send messages to multiple users simultaneously, creating a small group chat where only selected users can see the information.
+    messages:
+      what_are_messages:
+        title: What are Messages?
+        description: Messages are exchanges between users, such as topic discussions, private messages, comments, etc. Click on a user's avatar, then click the "Private Message" button in the user card to communicate one-on-one with them.
+      group_messaging:
+        title: Group Messaging
+        description: Similar to emails, you can also send messages to multiple users simultaneously, creating a small group chat where only selected users can see the information.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -71,7 +71,7 @@ en:
         description: If you have suggestions regarding tags, feel free to post and let us know your thoughts and suggestions. We welcome your participation in building the forum.
       quick_jump:
         title: Quick Jump
-        description: Clicking on different tags allows you to jump to the corresponding post list. Tips: You can also specify specific tags in the work list or during searches.
+        description: Clicking on different tags allows you to jump to the corresponding post list.You can also specify specific tags in the work list or during searches.
 
     categories:
       about_categories:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -71,7 +71,7 @@ zh-CN:
         description: 如果您有任何有关标签的建议，都可以发布帖子让我们知道您的意见和建议，欢迎您与我们共建论坛
       quick_jump:
         title: 快速跳转
-        description: 点击不同标签可以跳转至对应标签的帖子列表。tips：您也可以在作品列表或搜索的时候指定特定的标签
+        description: 点击不同标签可以跳转至对应标签的帖子列表。您也可以在作品列表或搜索的时候指定特定的标签
 
 		categories:
       about_categories:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -62,7 +62,7 @@ zh-CN:
         title: 徽章列表
         description: 一些徽章的获得的条件是公开的，在导航栏-更多-徽章页面，您可以看到公开的徽章列表。
 
-		tag_list:
+    tag_list:
       about_tags:
         title: 关于标签
         description: 除了自带的语言标签外，用户可以给自己的帖子带上相关的标签。点击“≡”打开侧边栏，可以快速查看不同标签分类下的内容
@@ -73,7 +73,7 @@ zh-CN:
         title: 快速跳转
         description: 点击不同标签可以跳转至对应标签的帖子列表。您也可以在作品列表或搜索的时候指定特定的标签
 
-		categories:
+    categories:
       about_categories:
         title: 关于类别
         description: 每一个帖子都只能选择一个类别，为了避免错误分类，请阅读不同类别下应该发表什么样的帖子
@@ -114,7 +114,7 @@ zh-CN:
         title: 创建一个群组
         description: 您可以随时私信联系<a href='/about'>管理人员</a>创建一个特定的群组并将您设定为群组管理人员
       contact_organizers:
-      	title: 联系组织人员
+        title: 联系组织人员
         description: 一些群组可能在APP和社区内为大家提供特定的帮助，您可以点击卡片查看详细说明、联系成员或者查看群组活动
 
     about:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -2,4 +2,144 @@ zh-CN:
   done: 完成
   next: 下一步
   prev: 上一步
-  message_title: "消息和通知区"
+  tutorials:
+    logged_startpage:
+      message_area_intro:
+        title: 消息区介绍
+        description: 点击右上角个人头像可以弹出消息界面
+      browse_messages:
+        title: 浏览消息
+        description: 在这里，您可以浏览所有与您有关的消息，点击右侧交互按钮查看对应类别的内容
+      goto_user_center:
+        title: 跳转用户中心
+        description: 点击这里跳转到用户中心，查看更多内容
+
+    summary:
+      personalization_settings:
+        title: 个性化设置
+        description: 论坛提供了丰富的可自定义功能，点击选项卡以查看不同功能。如果有任何问题，欢迎搜索或者联系我们<a href='/about'>友好的管理人员</a>
+
+    invited:
+      community_building:
+        title: 共建社区
+        description: 欢迎邀请更多用户来到我们的社区，成功邀请后您可以获得限定徽章
+
+    preferences:
+      profile_settings:
+        title: 个性设置
+        description: 填写个人资料，让大家更好的认识你吧！在这里，您可以设置个人网站、用户卡片背景、个性签名等
+      follow_unfollow:
+        title: 关注与取消关注
+        description: 在这里，您可以关注/取消关注特定类别、标签的帖子或话题
+      block_unblock_users:
+        title: 屏蔽与解除屏蔽用户
+        description: 在这里，您可以屏蔽/解除屏蔽特定的用户
+
+    own-badges:
+      more_badges:
+        title: 更多徽章
+        description: 这里列出了您所获得的全部徽章，访问<a href='/badges'>这里</a>可以查看更多未获得徽章
+
+    unlogged_startpage:
+      welcome_message:
+        title: 欢迎各位！
+        description: 欢迎来到物理实验室网页版社区！在这里，您可以像在APP社区一样发布作品、交流学习，亦或是分享趣事
+      login_invitation:
+        title: 登录账号加入我们吧
+        description: 在新版（2.6.8以后）中，将可以直接从应用访问社区。如果你已经注册了物理实验室帐号，将自动注册或登录网页版交流区帐号。如果你在物实没有验证邮箱，在交流区需要单独验证一次
+      sidebar_navigation:
+        title: 侧边栏导航
+        description: 点击'≡'打开侧边栏，在这里，您可以快速跳转到不同分区、标签的帖子，发起或查看私聊、群聊等。更多功能等待您的探索和发现
+
+    badges_list:
+      badge_explanation:
+        title: 什么是徽章？
+        description: 徽章是在论坛上用来表彰用户特定成就、贡献或者参与度的一种图标或徽记。完成特定任务、达到一定活跃度、获得特定荣誉或对社区做出杰出贡献，都将有机会获得属于您的徽章。
+      how_to_get_badges:
+        title: 如何获得徽章？
+        description: 点击具体徽章可以查看获取条件等，注册之后，也可以在我的-徽章里面查看并佩戴已获得的徽章
+      badge_list:
+        title: 徽章列表
+        description: 一些徽章的获得的条件是公开的，在导航栏-更多-徽章页面，您可以看到公开的徽章列表。
+
+		tag_list:
+      about_tags:
+        title: 关于标签
+        description: 除了自带的语言标签外，用户可以给自己的帖子带上相关的标签。点击“≡”打开侧边栏，可以快速查看不同标签分类下的内容
+      more_tags:
+        title: 更多标签
+        description: 如果您有任何有关标签的建议，都可以发布帖子让我们知道您的意见和建议，欢迎您与我们共建论坛
+      quick_jump:
+        title: 快速跳转
+        description: 点击不同标签可以跳转至对应标签的帖子列表。tips：您也可以在作品列表或搜索的时候指定特定的标签
+
+		categories:
+      about_categories:
+        title: 关于类别
+        description: 每一个帖子都只能选择一个类别，为了避免错误分类，请阅读不同类别下应该发表什么样的帖子
+      build_community:
+        title: 共建社区
+        description: 发现有帖子分类，可以点击下方 旗帜 形状的图标提示管理人员，详情查看<a href='/t/topic/294/1'>如何反馈不恰当内容</a>
+
+    unlogged_firstPost:
+      join_discussion:
+        title: 加入讨论吧
+        description: 优秀的看法总是在交流中诞生，注册或登录，与大家一齐讨论吧。
+      user_profile:
+        title: 用户资料
+        description: 不论是话题的发起者还是回复者，都可以点击头像查看TA的资料/名片。同时，您在发表看法的时候也无需署名
+      user_card:
+        title: 用户名片
+        description: 点击用户名可以查看详细资料，注册账号后，您也可以填写并生成您独一无二的名片
+
+    logged_firstPost:
+      notification_settings:
+        title: 通知设置
+        description: 您可以在此设置有关本话题活动的消息提示方式，例如：是否需要在有回复的时候显示为未读。对于您回复过的话题，我们会有一些默认的设置，您可以在个人设置-消息通知里面进行修改"
+      relevant_actions:
+        title: 相关操作
+        description: 操作栏里面可以进行点赞、翻译、收藏、加入书签、编辑帖子（如有权限）等操作。翻译、收藏、加入书签、编辑帖子（如有权限）等操作。如果您认为帖子有不合适的地方，可以点击旗帜图标进行举报
+      participate_discussion:
+        title: 参与讨论
+        description: 交流时请保持友善，共建美好社区。您可以点击侧边栏-更多-常见问题解答 查看发言注意事项请，或搜索FAQ
+
+    group:
+      what_is_group:
+        title: 什么是群组？
+        description: “群组”功能允许用户创建和加入特定主题或兴趣小组，促进围绕共同话题的深入交流与合作。
+      join_group:
+        title: 加入群组
+        description:除了系统默认的群组之外，你也可以加入一个群组与志同道合的人一起讨论。点击群组卡片，查看细内容，您可以选择直接申请或者通过私信功能与群组的管理员联系 
+      create_group:
+        title: 创建一个群组
+        description: 您可以随时私信联系<a href='/about'>管理人员</a>创建一个特定的群组并将您设定为群组管理人员
+      contact_organizers:
+      	title: 联系组织人员
+        description: 一些群组可能在APP和社区内为大家提供特定的帮助，您可以点击卡片查看详细说明、联系成员或者查看群组活动
+
+    about:
+      about_admins:
+        title: 关于“管理人员”
+        description: 有任何意见、建议、反馈都可以随时联系我们的管理人员，如果您希望创建新的标签、类别、群组，也可以发布帖子或者和管理人员一同讨论
+      private_messaging:
+        title: 私信功能
+        description: 您可以通过“私信”与管理人员取得联系。当然，也可以通过私信联系其他用户
+
+    notifications:
+      what_are_notifications:
+        title: 什么是“通知”？
+        description: 通知是系统向用户发送的信息，例如：当有人回复、点赞、@、私信你，或是有新的话题符合你的关注设定
+      notifications_and_messages:
+        title: “通知”与“消息”
+        description: 二者并不相同。消息是私信功能的收件箱，比如用户可以通过站内信功能向其他用户发送个人消息，进行一对一的沟通
+      personalization:
+        title: 个性化设置
+        description: 通知可以根据用户的偏好设置为即时推送、邮件通知等形式
+
+    messages:
+      what_are_messages:
+        title: 什么是“消息”？
+        description: 消息是用户间的交流内容，如主题讨论、私信、评论等。点击用户头像，在弹出的用户卡片里面点击私信按钮即可与用户一对一沟通
+      group_messaging:
+        title: 群发消息
+        description: 类似邮件，您也可以同时将消息发送给多位用户，此时就类似创建了一个小的群聊，只有选择的用户可以看到有关信息


### PR DESCRIPTION
Adjusted the navigation close logic to ensure that once a user closes any navigation, it won't be shown again for 30 minutes. (Following feedback gathered within the app, the majority of users expressed a preference for this approach.)

 Additionally, if any navigation is closed twice or more, or if the total number of navigation closures reaches six, all navigations will stop displaying